### PR TITLE
Update _originalImageWidth & _Height

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1471,6 +1471,8 @@
 
         self.data.orientation = getExifOffset(self.data.orientation, deg);
         drawCanvas(canvas, self.elements.img, self.data.orientation);
+        self._originalImageWidth = canvas.width;
+        self._originalImageHeight = canvas.height;
         _updateCenterPoint.call(self, true);
         _updateZoomLimits.call(self);
 


### PR DESCRIPTION
On rotate image, the _originalImageWidth & _originalImageHeight are not updated... So, the result was on the old value. This example, fix this issue.